### PR TITLE
Return items array after udpate operation.

### DIFF
--- a/opp/api/v1/items.py
+++ b/opp/api/v1/items.py
@@ -239,13 +239,12 @@ class ResponseHandler(bh.BaseResponseHandler):
 
         try:
             items = api.item_create(self.session, items)
+            response = []
+            for item in items:
+                response.append(item.extract(cipher))
+            return {'result': 'success', 'items': response}
         except Exception:
             raise bh.OppError("Unable to add new items to the database!")
-
-        response = []
-        for item in items:
-            response.append(item.extract(cipher))
-        return {'result': 'success', 'items': response}
 
     def _do_post(self, phrase):
         """
@@ -302,7 +301,10 @@ class ResponseHandler(bh.BaseResponseHandler):
 
         try:
             api.item_update(self.session, items)
-            return {'result': "success"}
+            response = []
+            for item in items:
+                response.append(item.extract(cipher))
+            return {'result': 'success', 'items': response}
         except Exception:
             raise bh.OppError("Unable to update items in the database!")
 


### PR DESCRIPTION
Items endpoind now returns the updated items in the response to
the update (POST) action. This is needed in case user chooses
to auto-generate the password during item update, which will be
performed on the backend and so the UI needs to know the new password
that was generated.

fixes #10